### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Require this package with composer using the following command:
 
 After updating composer, add the ServiceProviders to the providers array in `app/config/app.php`
 
-    Propel\PropelLaravel\GeneratorServiceProvider::class,
-    Propel\PropelLaravel\RuntimeServiceProvider::class,
+    Propel\PropelLaravel\PropelIntegrationServiceProvider::class,
 
 Next step is copy example config to your `app/config` directory.
 


### PR DESCRIPTION
as stated in UPGRADE.md:
Service providers
--------

Now package use only one service provider `PropelIntegrationServiceProvider`
and you must open your `config/app.php` file and replace:

    Allboo\PropelLaravel\GeneratorServiceProvider::class,
    Allboo\PropelLaravel\RuntimeServiceProvider::class,

with:

    Propel\PropelLaravel\PropelIntegrationServiceProvider::class,